### PR TITLE
add support for signalEntries

### DIFF
--- a/R/unisensR.R
+++ b/R/unisensR.R
@@ -7,6 +7,90 @@ NULL
 
 namespaces <- c(ns="http://www.unisens.org/unisens2.0")
 
+#' Read Unisens Signal Entry
+#'
+#' @export
+#'
+#' @param unisensFolder Unisens Folder
+#' @param id ID of the signal entry.
+#' @return DataFrame.
+#' @examples
+#' readUnisensSignalEntry('../UnisensR/inst/extdata/unisensExample', 'acc.bin')
+readUnisensSignalEntry <- function(unisensFolder, id){
+  if(unisensXMLExists(unisensFolder)){
+    doc <- xmlParse(paste(unisensFolder, 'unisens.xml', sep = '/'))
+    startTime <- readStartTime(doc)
+    xpath <- paste("//ns:signalEntry[@id='", id, "']", sep = '')
+    entries <- getNodeSet(doc, xpath, namespaces )
+    if(length(entries) <= 0) stop(paste('No SignalEntry found with name', id))
+    entry <- entries[[1]]
+
+    sampleRate <- as.numeric(xmlGetAttr(entry, "sampleRate"))
+
+    lsbValue <- as.numeric(xmlGetAttr(entry,"lsbValue"))
+    if (length(lsbValue)==0)
+    {
+      lsbValue <- 1;
+    }
+
+    baseline <- as.numeric(xmlGetAttr(entry,"baseline"))
+    if (length(baseline) ==0)
+    {
+      baseline <- 0;
+    }
+
+    channelNames <- getEntryChannelNames(entry)
+    nChannels <- length(channelNames)
+
+    entryPath <- paste(unisensFolder, id, sep = .Platform$file.sep)
+
+    if (length(getNodeSet(entry, "ns:binFileFormat", namespaces )) == 1)
+    {
+      dataType <- xmlGetAttr(entry, "dataType")
+      if (dataType=="int16")
+      {
+        rbSize <- 2;
+        rbType <- "integer"
+        rbSigned <- 1
+      }
+      else
+      {
+        stop("Datatype not defined yet.")
+      }
+
+      rbN <- file.info(entryPath)$size / rbSize
+
+      signalDataVec <- readBin(entryPath, rbType, n = rbN,  size = rbSize, signed = rbSigned, endian = "little")
+      signalData <- matrix(signalDataVec, ncol = nChannels, byrow = TRUE)
+      signalDataFrame <- as.data.frame(signalData)
+    }
+    else if (length(getNodeSet(entry, "ns:csvFileFormat", namespaces )) == 1)
+    {
+      csvFileFormatElement<-getNodeSet(entry, "ns:csvFileFormat", namespaces )[[1]]
+      separator <- xmlGetAttr(csvFileFormatElement, "separator")
+      signalDataFrame <- read.csv(paste(unisensFolder, id, sep = .Platform$file.sep), header = FALSE, sep = separator)
+    }
+    else {
+      stop('Unknown entry file format.');
+    }
+    if ((baseline!=0) | (lsbValue!=1))
+    {
+      signalDataFrame <- (signalDataFrame - baseline) * lsbValue
+    }
+
+    attr(signalDataFrame,"sampleRate") <- sampleRate
+    attr(signalDataFrame, "startTime") <- startTime
+
+    colnames(signalDataFrame) <- channelNames
+
+
+    free(doc)
+    return(signalDataFrame)
+  }
+  else
+    stop('Folder does not contain Unisens data!')
+}
+
 #' Read Unisens Values Entry
 #'
 #' @export
@@ -25,11 +109,39 @@ readUnisensValuesEntry <- function(unisensFolder, id){
     if(length(entries) <= 0) stop(paste('No ValuesEntry found with name', id))
     entry <- entries[[1]]
     sampleRate <- as.numeric(xmlGetAttr(entry, "sampleRate"))
-    csvData <- read.csv(paste(unisensFolder, id, sep = .Platform$file.sep), header = FALSE, sep = ",")
-    csvData <- setTime(csvData, start, sampleRate)
-    csvData <- setValuesEntryColumnNames(entry, csvData)
+    lsbValue <- as.numeric(xmlGetAttr(entry,"lsbValue"))
+    if (length(lsbValue)==0)
+    {
+      lsbValue <- 1;
+    }
+
+    baseline <- as.numeric(xmlGetAttr(entry,"baseline"))
+    if (length(baseline) ==0)
+    {
+      baseline <- 0;
+    }
+    if (length(getNodeSet(entry, "ns:binFileFormat", namespaces )) == 1)
+    {
+      stop("Values in binFileFormat not implemented.")
+    }
+    else if (length(getNodeSet(entry, "ns:csvFileFormat", namespaces )) == 1)
+    {
+      csvFileFormatElement<-getNodeSet(entry, "ns:csvFileFormat", namespaces )[[1]]
+      separator <- xmlGetAttr(csvFileFormatElement, "separator")
+      valuesDataFrame <- read.csv(paste(unisensFolder, id, sep = .Platform$file.sep), header = FALSE, sep = separator)
+    }
+    else {
+      stop('Unknown entry file format.');
+    }
+    if ((baseline!=0) | (lsbValue!=1))
+    {
+      valuesDataFrame <- (valuesDataFrame - baseline) * lsbValue
+    }
+    valuesDataFrame <- setTime(valuesDataFrame, start, sampleRate)
+    valuesDataFrame <- setValuesEntryColumnNames(entry, valuesDataFrame)
+
     free(doc)
-    return(csvData)
+    return(valuesDataFrame)
   }
   else
     stop('Folder does not contain Unisens data!')
@@ -58,11 +170,23 @@ readUnisensEventEntry <- function(unisensFolder, id){
     if(length(entries) <= 0) stop(paste('No EventEntry found with name', id))
     entry <- entries[[1]]
     sampleRate <- as.numeric(xmlGetAttr(entry, "sampleRate"))
-    csvData <- read.csv(paste(unisensFolder, id, sep = .Platform$file.sep), header = FALSE, sep = ",")
-    csvData <- setTime(csvData, start, sampleRate)
-    csvData <- setEventEntryColumnNames(entry, csvData)
+    if (length(getNodeSet(entry, "ns:binFileFormat", namespaces )) == 1)
+    {
+      stop("Event in binFileFormat not implemented.")
+    }
+    else if (length(getNodeSet(entry, "ns:csvFileFormat", namespaces )) == 1)
+    {
+      csvFileFormatElement<-getNodeSet(entry, "ns:csvFileFormat", namespaces )[[1]]
+      separator <- xmlGetAttr(csvFileFormatElement, "separator")
+      eventDataFrame <- read.csv(paste(unisensFolder, id, sep = .Platform$file.sep), header = FALSE, sep = separator)
+    }
+    else {
+      stop('Unknown entry file format.');
+    }
+    eventDataFrame <- setTime(eventDataFrame, start, sampleRate)
+    eventDataFrame <- setEventEntryColumnNames(entry, eventDataFrame)
     free(doc)
-    return(csvData)
+    return(eventDataFrame)
   }
   else
     stop('Folder does not contain Unisens data!')
@@ -75,16 +199,23 @@ setTime <- function(data, startTime, sampleRate) {
 }
 
 setValuesEntryColumnNames <- function(entry, data) {
-  entryDoc <- xmlDoc(entry)
-  channels <- getNodeSet(entryDoc, "//ns:channel", namespaces )
-  free(entryDoc)
-  channelNames <- sapply(channels, function(el) xmlGetAttr(el, "name"))
+  channelNames <- getEntryChannelNames(entry)
   colnames(data) <- c('Time', channelNames)
   return(data)
 }
 
+getEntryChannelNames <- function(entry)
+{
+  channels <- getNodeSet(entry, "ns:channel", namespaces )
+  channelNames <- sapply(channels, function(el) xmlGetAttr(el, "name"))
+  return(channelNames)
+}
+
 setEventEntryColumnNames <- function(entry, data) {
-  channelNames <- c('Time', 'Marker', 'Comment')
+  if (ncol(data) == 2)
+    channelNames <- c('Time', 'Marker')
+  else
+    channelNames <- c('Time', 'Marker', 'Comment')
   colnames(data) <- channelNames
   return(data)
 }


### PR DESCRIPTION
support to read signal entries in bin (int16 only) and csv file format
use separator specified in unisens.xml for csv file format
